### PR TITLE
Add early stopping test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ python3 example1.py
 
 python3 example2.py
 ![image](./Graphs/example2.png)
+
+## Running tests
+
+After installing `numpy` and `scipy`, you can run the included tests with:
+
+```bash
+pytest
+```

--- a/tests/test_restart_threshold.py
+++ b/tests/test_restart_threshold.py
@@ -1,0 +1,29 @@
+import sys, os
+import numpy as np
+
+# add library paths
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'GMRES_API'))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'RestartAlgorithm_API'))
+
+import GMRES
+import RestartAlgorithm
+
+
+def test_restart_algorithm_stops_early():
+    A = np.array([[4.0, 1.0],
+                  [2.0, 3.0]])
+    b = np.array([1.0, 1.0])
+
+    kernel = GMRES.GMRES_API(A, b, 1)
+    kernel.methods_used_to_solve_leastSqare_register('leastSquare_solver_numpy')
+    restart = RestartAlgorithm.RestartAlgorithm()
+    restart.kernel_algorithm_register(kernel)
+    restart.restart_initial_input(np.zeros(len(A)))
+    restart.maximum_restarting_iteration_register(5)
+    restart.restarting_iteration_ending_threshold_register(1e-1)
+
+    x, trend = restart.run_restart()
+
+    assert len(trend) < 5
+    assert trend[-1] < 1e-1
+    assert np.allclose(np.dot(A, x), b, atol=1e-1)


### PR DESCRIPTION
## Summary
- cover restart algorithm early stopping logic with a new test
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68550523ecf48324b4ac59f046b3d48b